### PR TITLE
Fix member selector on weekly affectation screen

### DIFF
--- a/src/lib/memberCategorizer.js
+++ b/src/lib/memberCategorizer.js
@@ -49,7 +49,7 @@ export function getCategorizedMembers({
 
   // For specific assignments, we need to filter by the exact date and slot type
   // specificAssignments from unifiedScheduleContext are already filtered for the current date/slot
-  const currentSpecificAssignments = specificAssignments() || [];
+  const currentSpecificAssignments = specificAssignments || [];
   const assignedMemberIds = new Set([
     ...currentAssignments.map((a) => a.member_id),
     ...(Array.isArray(currentSpecificAssignments)


### PR DESCRIPTION
Fixed TypeError where specificAssignments was incorrectly called as a function in getCategorizedMembers(). The parameter is an array, not a function, causing the "s is not a function" error when clicking the plus button to add members.