### PR TITLE
Filter absences page to show only current and future absences

### DIFF
--- a/controllers/absenceController.js
+++ b/controllers/absenceController.js
@@ -6,10 +6,11 @@ class AbsenceController {
     this.auditService = auditService;
   }
 
-  // GET /api/absences
+  // GET /api/absences?fromDate=YYYY-MM-DD
   async getAbsences(req, res, next) {
     try {
-      const absences = await this.absenceService.getAbsences();
+      const { fromDate } = req.query;
+      const absences = await this.absenceService.getAbsences(fromDate);
       res.json(absences);
     } catch (error) {
       next(error);

--- a/database.js
+++ b/database.js
@@ -277,14 +277,29 @@ class Database {
   }
 
   // Absences methods
-  getAllAbsences(callback) {
-    this.db.all(`
+  getAllAbsences(fromDate = null, callback) {
+    // Handle case where fromDate is not provided (callback is second argument)
+    if (typeof fromDate === 'function') {
+      callback = fromDate;
+      fromDate = null;
+    }
+
+    let query = `
       SELECT a.*, m.first_name, m.last_name,
              (m.first_name || CASE WHEN m.last_name != "" THEN " " || m.last_name ELSE "" END) as member_name
       FROM absences a
       JOIN members m ON a.member_id = m.id
-      ORDER BY a.start_date DESC, m.first_name, m.last_name
-    `, callback);
+    `;
+
+    const params = [];
+    if (fromDate) {
+      query += ' WHERE a.end_date >= ?';
+      params.push(fromDate);
+    }
+
+    query += ' ORDER BY a.start_date DESC, m.first_name, m.last_name';
+
+    this.db.all(query, params, callback);
   }
 
   addAbsence(memberId, startDate, endDate, startSlot = 'ouverture', endSlot = 'fermeture', callback) {

--- a/services/absenceService.js
+++ b/services/absenceService.js
@@ -4,11 +4,21 @@ class AbsenceService {
   constructor(database) {
     this.db = database;
     // Convert callback-based methods to promise-based
-    this.getAllAbsences = promisify(this.db.getAllAbsences.bind(this.db));
+    // Note: getAllAbsences needs special handling due to optional parameter
     this.addAbsence = promisify(this.db.addAbsence.bind(this.db));
     this.deleteAbsence = promisify(this.db.deleteAbsence.bind(this.db));
     this.getAbsencesForDateRange = promisify(this.db.getAbsencesForDateRange.bind(this.db));
     this.isMemberAbsentForSlot = promisify(this.db.isMemberAbsentForSlot.bind(this.db));
+  }
+
+  // Custom promisified version of getAllAbsences to handle optional fromDate parameter
+  getAllAbsences(fromDate = null) {
+    return new Promise((resolve, reject) => {
+      this.db.getAllAbsences(fromDate, (err, rows) => {
+        if (err) reject(err);
+        else resolve(rows);
+      });
+    });
   }
 
   async createAbsence(memberId, startDate, endDate, startSlot = 'ouverture', endSlot = 'fermeture') {
@@ -198,9 +208,9 @@ class AbsenceService {
     };
   }
 
-  async getAbsences() {
+  async getAbsences(fromDate = null) {
     try {
-      const absences = await this.getAllAbsences();
+      const absences = await this.getAllAbsences(fromDate);
       return absences;
     } catch (error) {
       throw new Error(`Failed to fetch absences: ${error.message}`);

--- a/src/lib/absenceService.js
+++ b/src/lib/absenceService.js
@@ -23,10 +23,14 @@ async function handleResponse(response) {
 
 export const absenceService = {
   /**
-   * Get all absences
+   * Get absences, optionally filtered by fromDate (only absences ending on or after this date)
+   * @param {string} fromDate - Optional date in YYYY-MM-DD format
    */
-  async getAbsences() {
-    const response = await fetch(`${API_BASE}/absences`);
+  async getAbsences(fromDate = null) {
+    const url = fromDate
+      ? `${API_BASE}/absences?fromDate=${encodeURIComponent(fromDate)}`
+      : `${API_BASE}/absences`;
+    const response = await fetch(url);
     return handleResponse(response);
   },
 

--- a/src/pages/AbsencesPage.svelte
+++ b/src/pages/AbsencesPage.svelte
@@ -19,13 +19,28 @@
     await loadData();
   });
 
+  // Helper function to get Monday of the current week
+  function getCurrentWeekMonday() {
+    const today = new Date();
+    const dayOfWeek = today.getDay(); // 0 = Sunday, 1 = Monday, ..., 6 = Saturday
+    const daysFromMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1; // If Sunday, go back 6 days
+    const monday = new Date(today);
+    monday.setDate(today.getDate() - daysFromMonday);
+    // Format as YYYY-MM-DD
+    return monday.toISOString().split('T')[0];
+  }
+
   async function loadData() {
     isLoading = true;
     error = null;
     try {
+      // Get current week's Monday to filter absences
+      const currentWeekMonday = getCurrentWeekMonday();
+
       // Load both absences and members data
+      // Only load absences ending on or after current week's Monday
       const [absencesData] = await Promise.all([
-        absenceService.getAbsences(),
+        absenceService.getAbsences(currentWeekMonday),
         assignmentActions.loadData()
       ]);
       absences = absencesData;


### PR DESCRIPTION
Modified the absences API and page to only load absences with end dates from the current week's Monday onwards, instead of showing all historical absences.

## Changes

**Backend:**
- Updated database.getAllAbsences() to accept optional fromDate parameter
- Modified absenceService to handle date filtering
- Updated absenceController to accept fromDate query parameter

**Frontend:**
- Added getCurrentWeekMonday() helper function
- Updated loadData() to calculate and pass current week's Monday
- Modified API client to support fromDate query parameter

Closes #10

Generated with [Claude Code](https://claude.ai/code)