### PR TITLE
refactor: replace expandable list with calendar view

### DIFF
--- a/src/components/absences/MemberAbsenceCalendar.svelte
+++ b/src/components/absences/MemberAbsenceCalendar.svelte
@@ -1,0 +1,184 @@
+<script>
+  /**
+   * Compact calendar component showing absence periods for a member
+   * Displays 3 months (current + next 2) with absence periods highlighted
+   * @typedef {Object} Props
+   * @property {Array} absences - List of absence objects with start_date, end_date, start_slot, end_slot
+   */
+
+  /** @type {Props} */
+  let { absences = [] } = $props();
+
+  // Get current date and generate 3 months to display
+  function generateMonths() {
+    const today = new Date();
+    const months = [];
+
+    for (let i = 0; i < 3; i++) {
+      const date = new Date(today.getFullYear(), today.getMonth() + i, 1);
+      months.push({
+        year: date.getFullYear(),
+        month: date.getMonth(),
+        monthName: date.toLocaleDateString('fr-FR', { month: 'short' }),
+        days: generateMonthDays(date)
+      });
+    }
+
+    return months;
+  }
+
+  function generateMonthDays(monthDate) {
+    const year = monthDate.getFullYear();
+    const month = monthDate.getMonth();
+    const firstDay = new Date(year, month, 1);
+    const lastDay = new Date(year, month + 1, 0);
+    const daysInMonth = lastDay.getDate();
+
+    // Get day of week for first day (0 = Sunday, 1 = Monday, etc.)
+    // Convert to Monday = 0
+    let firstDayOfWeek = firstDay.getDay() - 1;
+    if (firstDayOfWeek === -1) firstDayOfWeek = 6;
+
+    const days = [];
+
+    // Add empty cells for days before month starts
+    for (let i = 0; i < firstDayOfWeek; i++) {
+      days.push({ date: null, dateString: null });
+    }
+
+    // Add days of month
+    for (let day = 1; day <= daysInMonth; day++) {
+      const date = new Date(year, month, day);
+      const dateString = date.toISOString().split('T')[0];
+      days.push({ date: day, dateString });
+    }
+
+    return days;
+  }
+
+  function isAbsent(dateString) {
+    if (!dateString) return null;
+
+    const date = new Date(dateString);
+
+    for (const absence of absences) {
+      const startDate = new Date(absence.start_date);
+      const endDate = new Date(absence.end_date);
+
+      if (date >= startDate && date <= endDate) {
+        // Determine if it's partial day absence
+        const isStartDate = dateString === absence.start_date;
+        const isEndDate = dateString === absence.end_date;
+        const isSingleDay = absence.start_date === absence.end_date;
+
+        if (isSingleDay) {
+          // Single day absence
+          if (absence.start_slot === 'ouverture' && absence.end_slot === 'fermeture') {
+            return 'full'; // All day
+          } else if (absence.start_slot === absence.end_slot) {
+            return absence.start_slot === 'ouverture' ? 'morning' : 'evening';
+          } else {
+            return 'full'; // Mixed slots
+          }
+        } else {
+          // Multi-day absence
+          if (isStartDate && absence.start_slot === 'fermeture') {
+            return 'evening'; // Only evening of start date
+          } else if (isEndDate && absence.end_slot === 'ouverture') {
+            return 'morning'; // Only morning of end date
+          } else {
+            return 'full'; // Full day
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  function getDayClass(dateString) {
+    const absenceType = isAbsent(dateString);
+    if (!absenceType) return 'bg-slate-800/50 hover:bg-slate-700/50';
+
+    if (absenceType === 'full') {
+      return 'bg-red-600/80 hover:bg-red-500/80 text-white font-medium';
+    } else if (absenceType === 'morning') {
+      return 'bg-gradient-to-b from-red-600/80 to-slate-800/50 hover:from-red-500/80 hover:to-slate-700/50 text-white font-medium';
+    } else if (absenceType === 'evening') {
+      return 'bg-gradient-to-b from-slate-800/50 to-red-600/80 hover:from-slate-700/50 hover:to-red-500/80 text-white font-medium';
+    }
+  }
+
+  function isToday(dateString) {
+    if (!dateString) return false;
+    const today = new Date().toISOString().split('T')[0];
+    return dateString === today;
+  }
+
+  let months = $derived(generateMonths());
+</script>
+
+<div class="p-2 md:p-3">
+  {#if absences.length === 0}
+    <div class="py-4 text-center">
+      <p class="text-xs text-slate-400">Aucune absence enregistrée</p>
+    </div>
+  {:else}
+    <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
+      {#each months as month}
+        <div class="overflow-hidden border rounded-lg bg-slate-900/50 border-slate-700/50">
+          <!-- Month header -->
+          <div class="px-2 py-1 text-xs font-medium text-center text-slate-300 bg-slate-800/80">
+            {month.monthName} {month.year}
+          </div>
+
+          <!-- Day labels -->
+          <div class="grid grid-cols-7 gap-px p-1 text-[9px] font-medium text-center text-slate-500 bg-slate-900/50">
+            <div>L</div>
+            <div>M</div>
+            <div>M</div>
+            <div>J</div>
+            <div>V</div>
+            <div>S</div>
+            <div>D</div>
+          </div>
+
+          <!-- Calendar grid -->
+          <div class="grid grid-cols-7 gap-px p-1 bg-slate-900/50">
+            {#each month.days as day}
+              {#if day.date}
+                <div
+                  class="relative flex items-center justify-center w-full text-[10px] transition-colors rounded aspect-square {getDayClass(day.dateString)}"
+                  title={day.dateString}
+                >
+                  <span class="relative z-10">{day.date}</span>
+                  {#if isToday(day.dateString)}
+                    <div class="absolute inset-0 border-2 border-blue-400 rounded animate-pulse"></div>
+                  {/if}
+                </div>
+              {:else}
+                <div class="w-full aspect-square"></div>
+              {/if}
+            {/each}
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    <!-- Legend -->
+    <div class="flex flex-wrap gap-2 mt-3 text-[10px] text-slate-400">
+      <div class="flex items-center gap-1">
+        <div class="w-3 h-3 rounded bg-red-600/80"></div>
+        <span>Journée complète</span>
+      </div>
+      <div class="flex items-center gap-1">
+        <div class="w-3 h-3 rounded bg-gradient-to-b from-red-600/80 to-slate-800/50"></div>
+        <span>Matin uniquement</span>
+      </div>
+      <div class="flex items-center gap-1">
+        <div class="w-3 h-3 rounded bg-gradient-to-b from-slate-800/50 to-red-600/80"></div>
+        <span>Soir uniquement</span>
+      </div>
+    </div>
+  {/if}
+</div>

--- a/src/components/absences/MemberAbsencePanel.svelte
+++ b/src/components/absences/MemberAbsencePanel.svelte
@@ -1,4 +1,5 @@
 <script>
+  import MemberAbsenceCalendar from './MemberAbsenceCalendar.svelte';
   import AbsenceCard from './AbsenceCard.svelte';
 
   /**
@@ -14,16 +15,7 @@
   /** @type {Props} */
   let { member, absences, formatPeriod, onDelete, onaddabsence } = $props();
 
-  const INITIAL_DISPLAY_COUNT = 3;
-  let isExpanded = $state(false);
-
-  // Show only first 3 absences unless expanded
-  let displayedAbsences = $derived(
-    isExpanded ? absences : absences.slice(0, INITIAL_DISPLAY_COUNT)
-  );
-
-  let hasMoreAbsences = $derived(absences.length > INITIAL_DISPLAY_COUNT);
-  let remainingCount = $derived(absences.length - INITIAL_DISPLAY_COUNT);
+  let viewMode = $state('calendar'); // 'calendar' or 'list'
 
   function handleAddAbsence() {
     // Create a proper event-like object
@@ -33,55 +25,57 @@
     onaddabsence?.(event);
   }
 
-  function toggleExpanded() {
-    isExpanded = !isExpanded;
+  function toggleViewMode() {
+    viewMode = viewMode === 'calendar' ? 'list' : 'calendar';
   }
 </script>
 
 <div class="overflow-hidden bg-gradient-to-br rounded-2xl border shadow-2xl backdrop-blur-xl from-slate-800/90 via-slate-900/95 to-slate-800/90 border-slate-700/50">
-  <!-- Panel header with member name and add button -->
+  <!-- Panel header with member name and buttons -->
   <div class="flex items-center justify-between px-3 py-2 bg-gradient-to-r border-b backdrop-blur-sm border-slate-700/50 from-slate-800/80 to-slate-900/80 md:px-4 md:py-3">
     <h3 class="text-base font-medium text-transparent bg-clip-text bg-gradient-to-r from-white to-slate-200 md:text-lg">
       {member.first_name} {member.last_name}
     </h3>
-    <button
-      onclick={handleAddAbsence}
-      class="px-2 py-1.5 text-xs font-medium text-white transition-all duration-200 bg-gradient-to-r rounded-lg shadow-lg from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 hover:shadow-xl hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500/50 md:px-3 md:py-2 md:text-sm"
-    >
-      + Absence
-    </button>
-  </div>
-
-  <!-- Absences list for this member -->
-  <div class="p-2 md:p-3">
-    {#if absences.length === 0}
-      <div class="py-6 text-center md:py-8">
-        <p class="text-sm text-slate-400">Aucune absence enregistrée</p>
-      </div>
-    {:else}
-      <div class="space-y-1.5">
-        {#each displayedAbsences as absence (absence.id)}
-          <AbsenceCard
-            {absence}
-            {formatPeriod}
-            {onDelete}
-            hideMemberInfo={true}
-          />
-        {/each}
-      </div>
-
-      {#if hasMoreAbsences}
+    <div class="flex gap-2">
+      {#if absences.length > 0}
         <button
-          onclick={toggleExpanded}
-          class="w-full px-2 py-1.5 mt-2 text-xs font-medium transition-all duration-200 rounded-lg text-slate-300 bg-slate-700/50 hover:bg-slate-600/50 focus:outline-none focus:ring-2 focus:ring-blue-500/50 md:text-sm"
+          onclick={toggleViewMode}
+          class="px-2 py-1.5 text-xs font-medium transition-all duration-200 rounded-lg text-slate-300 bg-slate-700/50 hover:bg-slate-600/50 focus:outline-none focus:ring-2 focus:ring-blue-500/50 md:text-sm"
+          title={viewMode === 'calendar' ? 'Voir la liste' : 'Voir le calendrier'}
         >
-          {#if isExpanded}
-            Afficher moins
-          {:else}
-            Afficher {remainingCount} absence{remainingCount > 1 ? 's' : ''} de plus
-          {/if}
+          {viewMode === 'calendar' ? '📋' : '📅'}
         </button>
       {/if}
-    {/if}
+      <button
+        onclick={handleAddAbsence}
+        class="px-2 py-1.5 text-xs font-medium text-white transition-all duration-200 bg-gradient-to-r rounded-lg shadow-lg from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 hover:shadow-xl hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500/50 md:px-3 md:py-2 md:text-sm"
+      >
+        + Absence
+      </button>
+    </div>
   </div>
+
+  <!-- Calendar or List view -->
+  {#if viewMode === 'calendar'}
+    <MemberAbsenceCalendar {absences} />
+  {:else}
+    <div class="p-2 md:p-3">
+      {#if absences.length === 0}
+        <div class="py-6 text-center md:py-8">
+          <p class="text-sm text-slate-400">Aucune absence enregistrée</p>
+        </div>
+      {:else}
+        <div class="space-y-1.5">
+          {#each absences as absence (absence.id)}
+            <AbsenceCard
+              {absence}
+              {formatPeriod}
+              {onDelete}
+              hideMemberInfo={true}
+            />
+          {/each}
+        </div>
+      {/if}
+    </div>
+  {/if}
 </div>


### PR DESCRIPTION
### Summary

Replaces the problematic "show more" expandable list with a visual calendar view that prevents endless scrolling and makes absences easier to browse.

### Changes

- ✅ New `MemberAbsenceCalendar.svelte` component with 3-month view
- ✅ Visual indicators for full day, morning-only, and evening-only absences
- ✅ Calendar/list view toggle for flexibility
- ✅ Compact design prevents 'neverending scroll' issue
- ✅ Responsive layout: stacked on mobile, 3-column on desktop
- ✅ French localization with legend

### Result

The absence page is now much easier to browse with a visual calendar showing all absence periods at a glance. No more endless scrolling through long lists. Users can toggle to list view when they need detailed information.

Fixes #12

Generated with [Claude Code](https://claude.ai/code)