### PR TITLE
refactor: simplify absence display to inline tags

### DIFF
--- a/src/components/absences/MemberAbsenceMonthList.svelte
+++ b/src/components/absences/MemberAbsenceMonthList.svelte
@@ -2,17 +2,50 @@
   import DeleteButton from '../common/DeleteButton.svelte';
 
   /**
-   * Month-based list component showing absences grouped by month
+   * Month-based list component showing absences as inline tags grouped by month
    * @typedef {Object} Props
    * @property {Array} absences - List of absence objects with start_date, end_date, start_slot, end_slot
-   * @property {function} formatPeriod - Function to format date periods
    * @property {function} onDelete - Delete handler function
    */
 
   /** @type {Props} */
-  let { absences = [], formatPeriod, onDelete } = $props();
+  let { absences = [], onDelete } = $props();
 
-  // Group absences by month
+  /**
+   * Split multi-month absences into separate periods per month
+   */
+  function splitAbsencesByMonth(absence) {
+    const startDate = new Date(absence.start_date);
+    const endDate = new Date(absence.end_date);
+
+    const periods = [];
+    let currentDate = new Date(startDate);
+
+    while (currentDate <= endDate) {
+      const monthStart = new Date(currentDate);
+      const monthEnd = new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 0);
+
+      const periodStart = currentDate.getTime() === startDate.getTime() ? startDate : monthStart;
+      const periodEnd = monthEnd < endDate ? monthEnd : endDate;
+
+      periods.push({
+        ...absence,
+        displayStartDate: periodStart,
+        displayEndDate: periodEnd,
+        monthKey: `${currentDate.getFullYear()}-${String(currentDate.getMonth() + 1).padStart(2, '0')}`,
+        monthName: currentDate.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' })
+      });
+
+      // Move to next month
+      currentDate = new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 1);
+    }
+
+    return periods;
+  }
+
+  /**
+   * Group absences by month and split multi-month periods
+   */
   function groupAbsencesByMonth(absences) {
     const grouped = new Map();
 
@@ -21,22 +54,55 @@
       return new Date(a.start_date) - new Date(b.start_date);
     });
 
+    // Split multi-month absences and group by month
     sortedAbsences.forEach(absence => {
-      const startDate = new Date(absence.start_date);
-      const monthKey = `${startDate.getFullYear()}-${String(startDate.getMonth() + 1).padStart(2, '0')}`;
-      const monthName = startDate.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' });
+      const periods = splitAbsencesByMonth(absence);
 
-      if (!grouped.has(monthKey)) {
-        grouped.set(monthKey, {
-          monthName,
-          absences: []
-        });
-      }
+      periods.forEach(period => {
+        if (!grouped.has(period.monthKey)) {
+          grouped.set(period.monthKey, {
+            monthName: period.monthName,
+            periods: []
+          });
+        }
 
-      grouped.get(monthKey).absences.push(absence);
+        grouped.get(period.monthKey).periods.push(period);
+      });
     });
 
     return Array.from(grouped.values());
+  }
+
+  /**
+   * Format a period as inline text (e.g., "1", "du 8 au 12", "15 (ouverture)")
+   */
+  function formatPeriodTag(period) {
+    const startDay = period.displayStartDate.getDate();
+    const endDay = period.displayEndDate.getDate();
+    const isSameDay = period.displayStartDate.getTime() === period.displayEndDate.getTime();
+
+    let text = '';
+    let slotInfo = '';
+
+    if (isSameDay) {
+      text = `${startDay}`;
+      // For single day, show slot only if it's not a full day
+      if (period.start_slot === 'ouverture' && period.end_slot === 'ouverture') {
+        slotInfo = 'ouverture';
+      } else if (period.start_slot === 'fermeture' && period.end_slot === 'fermeture') {
+        slotInfo = 'fermeture';
+      }
+    } else {
+      text = `du ${startDay} au ${endDay}`;
+      // For multi-day within same month, show slot if not full range
+      if (period.start_slot === 'fermeture') {
+        slotInfo = 'début fermeture';
+      } else if (period.end_slot === 'ouverture') {
+        slotInfo = 'fin ouverture';
+      }
+    }
+
+    return { text, slotInfo };
   }
 
   let groupedAbsences = $derived(groupAbsencesByMonth(absences));
@@ -48,39 +114,37 @@
       <p class="text-xs text-slate-400 md:text-sm">Aucune absence enregistrée</p>
     </div>
   {:else}
-    <div class="space-y-3">
+    <div class="space-y-4">
       {#each groupedAbsences as monthGroup}
-        <div class="space-y-1.5">
+        <div class="space-y-2">
           <!-- Month header -->
-          <h4 class="text-xs font-semibold capitalize text-slate-300 md:text-sm">
-            {monthGroup.monthName}
+          <h4 class="text-sm font-semibold capitalize text-slate-300 md:text-base">
+            {monthGroup.monthName} :
           </h4>
 
-          <!-- Absences for this month -->
-          <div class="pl-2 space-y-1.5 border-l-2 border-slate-700/50 md:pl-3">
-            {#each monthGroup.absences as absence (absence.id)}
-              {@const period = formatPeriod(absence)}
-              <div class="flex items-start justify-between gap-2 p-2 border rounded-lg bg-gradient-to-br backdrop-blur-sm from-slate-700/40 to-slate-600/40 border-slate-600/30">
-                <div class="flex-1 min-w-0 text-xs md:text-sm">
-                  <div class="flex flex-row flex-wrap items-center gap-1">
-                    <span class="font-semibold text-slate-100">{period.startDate}</span>
-                    {#if period.startSlot}
-                      <span class="inline-block px-1.5 py-0.5 rounded bg-slate-600/80 text-[10px] md:text-xs text-amber-300 font-semibold">
-                        {period.startSlot}
-                      </span>
-                    {/if}
-                    {#if period.endDate}
-                      <span class="text-slate-400">→</span>
-                      <span class="font-semibold text-slate-100">{period.endDate}</span>
-                      {#if period.endSlot}
-                        <span class="inline-block px-1.5 py-0.5 rounded bg-slate-600/80 text-[10px] md:text-xs text-amber-300 font-semibold">
-                          {period.endSlot}
-                        </span>
-                      {/if}
-                    {/if}
-                  </div>
-                </div>
-                <DeleteButton onclick={() => onDelete(absence.id)} />
+          <!-- Inline tags for this month -->
+          <div class="flex flex-wrap gap-2 pl-3">
+            {#each monthGroup.periods as period (period.id + '-' + period.monthKey)}
+              {@const formatted = formatPeriodTag(period)}
+              <div class="group relative inline-flex items-center gap-1.5 px-3 py-1.5 text-xs md:text-sm rounded-lg bg-gradient-to-br from-slate-700/60 to-slate-600/60 border border-slate-600/40 hover:border-slate-500/60 transition-all duration-200 hover:shadow-lg">
+                <span class="text-slate-100 font-medium whitespace-nowrap">
+                  {formatted.text}
+                </span>
+                {#if formatted.slotInfo}
+                  <span class="text-[10px] md:text-xs text-amber-300/80 whitespace-nowrap">
+                    ({formatted.slotInfo})
+                  </span>
+                {/if}
+                <!-- Delete button - visible on hover -->
+                <button
+                  onclick={() => onDelete(period.id)}
+                  class="opacity-0 group-hover:opacity-100 transition-opacity duration-200 ml-1 p-0.5 rounded hover:bg-red-500/20 focus:outline-none focus:ring-1 focus:ring-red-500/50"
+                  aria-label="Supprimer cette absence"
+                >
+                  <svg class="w-3.5 h-3.5 text-red-400 hover:text-red-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
               </div>
             {/each}
           </div>

--- a/src/components/absences/MemberAbsencePanel.svelte
+++ b/src/components/absences/MemberAbsencePanel.svelte
@@ -6,13 +6,12 @@
    * @typedef {Object} Props
    * @property {Object} member - Member object with id, first_name, last_name
    * @property {Array} absences - List of absences for this member
-   * @property {function} formatPeriod - Function to format date periods
    * @property {function} onDelete - Delete handler function
    * @property {function} [onaddabsence] - Callback for add absence action
    */
 
   /** @type {Props} */
-  let { member, absences, formatPeriod, onDelete, onaddabsence } = $props();
+  let { member, absences, onDelete, onaddabsence } = $props();
 
   function handleAddAbsence() {
     // Create a proper event-like object
@@ -38,5 +37,5 @@
   </div>
 
   <!-- Month-based list view -->
-  <MemberAbsenceMonthList {absences} {formatPeriod} {onDelete} />
+  <MemberAbsenceMonthList {absences} {onDelete} />
 </div>

--- a/src/pages/AbsencesPage.svelte
+++ b/src/pages/AbsencesPage.svelte
@@ -278,7 +278,6 @@
             <MemberAbsencePanel
               {member}
               absences={member.absences}
-              {formatPeriod}
               onDelete={handleDelete}
               onaddabsence={handleAddAbsence}
             />


### PR DESCRIPTION
### Summary

Simplifies the absence page by replacing full-width cards with compact inline tags, making it much easier to browse absences.

### Changes

- ✅ Replace full-width absence cards with compact inline tags
- ✅ Add hover delete buttons to each tag
- ✅ Split multi-month periods into separate tags per month
- ✅ Display format: "1, 3, 5, du 8 au 12, 15 (ouverture)"
- ✅ Smart slot display for partial day absences

### Result

The absence page is now much more compact and scannable, with month headers followed by inline date tags. No more endless scrolling through large cards.

Fixes #12

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/BenjaminBini/bcfk/actions/runs/21516167238) | [Branch: claude/issue-12-20260130-1241](https://github.com/BenjaminBini/bcfk/tree/claude/issue-12-20260130-1241