### PR TITLE
fix: resolve absence modal reactivity bug

### DIFF
--- a/src/components/absences/MemberAbsenceMonthList.svelte
+++ b/src/components/absences/MemberAbsenceMonthList.svelte
@@ -185,7 +185,7 @@
 <DeleteAbsenceModal
   isOpen={showDeleteModal}
   {memberName}
-  periodText={selectedAbsence ? formatPeriodTag(selectedAbsence).text : ''}
+  absence={selectedAbsence}
   onConfirm={handleConfirmDelete}
   onCancel={handleCancelDelete}
 />

--- a/src/components/modals/DeleteAbsenceModal.svelte
+++ b/src/components/modals/DeleteAbsenceModal.svelte
@@ -5,7 +5,7 @@
    * @typedef {Object} Props
    * @property {boolean} [isOpen] - Whether modal is open
    * @property {string} [memberName] - Name of the member
-   * @property {string} [periodText] - Text description of the absence period
+   * @property {Object} [absence] - The absence object with date information
    * @property {function} [onConfirm] - Callback for confirm action
    * @property {function} [onCancel] - Callback for cancel action
    */
@@ -14,10 +14,31 @@
   let {
     isOpen = false,
     memberName = '',
-    periodText = '',
+    absence = null,
     onConfirm,
     onCancel
   } = $props();
+
+  /**
+   * Format the absence period for display
+   */
+  function formatPeriod(absence) {
+    if (!absence || !absence.displayStartDate || !absence.displayEndDate) {
+      return '';
+    }
+
+    const startDay = absence.displayStartDate.getDate();
+    const endDay = absence.displayEndDate.getDate();
+    const isSameDay = absence.displayStartDate.getTime() === absence.displayEndDate.getTime();
+
+    if (isSameDay) {
+      return `${startDay}`;
+    } else {
+      return `du ${startDay} au ${endDay}`;
+    }
+  }
+
+  let periodText = $derived(formatPeriod(absence));
 
   function handleConfirm() {
     onConfirm?.();


### PR DESCRIPTION
### Summary

Fixes bug where the absence deletion modal showed undefined/missing data when clicking on absence tags.

### Root Cause

The issue was a Svelte 5 reactivity problem. The `periodText` was being calculated outside the modal and passed as a static prop, breaking reactivity when `selectedAbsence` changed.

### Changes

- ✅ Updated `DeleteAbsenceModal` to accept absence object directly
- ✅ Added internal `formatPeriod` function with `$derived` for proper reactivity
- ✅ Updated `MemberAbsenceMonthList` to pass raw absence object

### Result

The modal now correctly displays member name and period information when clicking on any absence tag.

Fixes #12

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/BenjaminBini/bcfk/actions/runs/21535344789) | [Branch: claude/issue-12-20260131-0025](https://github.com/BenjaminBini/bcfk/tree/claude/issue-12-20260131-0025