### PR TITLE
fix: resolve absence modal reactivity bug

### DIFF
--- a/src/components/modals/DeleteAbsenceModal.svelte
+++ b/src/components/modals/DeleteAbsenceModal.svelte
@@ -22,7 +22,7 @@
   /**
    * Format the absence period for display
    */
-  function formatPeriod(absence) {
+  function getPeriodText() {
     if (!absence || !absence.displayStartDate || !absence.displayEndDate) {
       return '';
     }
@@ -37,8 +37,6 @@
       return `du ${startDay} au ${endDay}`;
     }
   }
-
-  let periodText = $derived(formatPeriod(absence));
 
   function handleConfirm() {
     onConfirm?.();
@@ -63,12 +61,18 @@
   {/snippet}
 
   {#snippet content()}
-    <p class="text-slate-200 text-sm">
-      Êtes-vous sûr de vouloir supprimer l'absence de <span class="font-semibold text-white">{memberName}</span> pour la période <span class="font-semibold text-white">{periodText}</span> ?
-    </p>
-    <p class="text-slate-400 text-xs mt-2">
-      Cette action est irréversible.
-    </p>
+    {#if absence}
+      <p class="text-slate-200 text-sm">
+        Êtes-vous sûr de vouloir supprimer l'absence de <span class="font-semibold text-white">{memberName}</span> pour la période <span class="font-semibold text-white">{getPeriodText()}</span> ?
+      </p>
+      <p class="text-slate-400 text-xs mt-2">
+        Cette action est irréversible.
+      </p>
+    {:else}
+      <p class="text-slate-200 text-sm">
+        Chargement...
+      </p>
+    {/if}
   {/snippet}
 
   {#snippet actions()}


### PR DESCRIPTION
### Summary

Fixes bug where the absence deletion modal showed empty data when clicking on absence tags.

### Root Cause

The issue was with Svelte 5's `$derived` rune not properly updating when the `absence` prop changed. The `periodText` was being calculated and stored, but wasn't reactively recalculating when a new absence was selected.

### Changes

- ✅ Removed `$derived` rune usage for `periodText`
- ✅ Changed to direct function call `getPeriodText()` in template
- ✅ Added `{#if absence}` guard to prevent empty display
- ✅ Ensures period text recalculates on every render

### Result

The modal now correctly displays the member name and period information when clicking on any absence tag.

Fixes #12

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/BenjaminBini/bcfk/actions/runs/21543940672) | [Branch: claude/issue-12-20260131-1141](https://github.com/BenjaminBini/bcfk/tree/claude/issue-12-20260131-1141